### PR TITLE
chore: Bump {clock} version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: datetimeoffset
 Type: Package
 Title: Datetimes with Optional UTC Offsets and/or Heterogeneous Time Zones
-Version: 0.4.1
+Version: 1.0.0-0
 Authors@R: c(
         person("Trevor L.", "Davis", role=c("aut", "cre"), email="trevor.l.davis@gmail.com",
                comment = c(ORCID = "0000-0001-6341-4639")))
@@ -21,7 +21,7 @@ RoxygenNote: 7.3.1
 Depends:
     R (>= 3.4.0)
 Imports:
-    clock (>= 0.7.0),
+    clock (>= 0.7.3),
     methods,
     purrr (>= 1.0.0),
     vctrs (>= 0.5.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+datetimeoffset 1.0.0
+====================
+
+Bumps required `{clock}` version to version 0.7.3 (#64).
+
 datetimeoffset 0.4.1
 ====================
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,13 +1,9 @@
-* The `gcc-UBSAN` issue should now be resolved:
-
-  + The issue has been reported and fixed upstream in `{nanotime}`
-  + Tests are now skipped for earlier versions of `{nanotime}`
+* Bumps required {clock} version to prevent R CMD check ERROR on CRAN
 
 ## Test environments
 
-* local (linux, R 4.4.2)
-* mac-builder (macOS, R devel)
-* win-builder (windows, R release))
+* local (linux, R 4.4.3)
+* win-builder (windows, R devel)
 * github actions (windows, R release)
 * github actions (macOS, R release)
 * github actions (linux, R devel)

--- a/tests/testthat/test-as_datetimeoffset.r
+++ b/tests/testthat/test-as_datetimeoffset.r
@@ -250,6 +250,7 @@ test_that("ISO week dates", {
 })
 
 test_that("base R classes", {
+    skip_if_not_installed("clock", "0.7.3")
     # Date
     s <- c("2020-05-15", NA_character_)
     expect_equal(format(as_datetimeoffset(as.Date(s))), s)
@@ -302,6 +303,8 @@ test_that("base R classes", {
 })
 
 test_that("{clock} classes", {
+    skip_if_not_installed("clock", "0.7.3")
+
     ymd <- clock::year_month_day(2020, c(NA, 10), 10)
     dto <- as_datetimeoffset(ymd)
     expect_equal(format(dto), c(NA_character_, "2020-10-10"))

--- a/tests/testthat/test-from-datetimeoffset.r
+++ b/tests/testthat/test-from-datetimeoffset.r
@@ -69,6 +69,8 @@ test_that("`as.parttime.datetimeoffset()` and `as_datetimeoffset.parttime()`", {
 })
 
 test_that("as.POSIXct()", {
+    skip_if_not_installed("clock", "0.7.3")
+
     expect_equal(format(as.POSIXct("2020-03-23 04:04:04")),
                  format(as.POSIXct(as_datetimeoffset("2020-03-23 04:04:04", tz=""))))
     expect_equal(format(as.POSIXct("2020-03-23 04:04:04")),
@@ -101,6 +103,8 @@ test_that("as.POSIXct()", {
 })
 
 test_that("as.POSIXlt()", {
+    skip_if_not_installed("clock", "0.7.3")
+
     expect_equal(format(as.POSIXlt("2020-03-23 04:04:04")),
                  format(as.POSIXlt(as_datetimeoffset("2020-03-23 04:04:04", tz=""))))
     skip_if_not(all(c("America/Los_Angeles", "America/New_York") %in% OlsonNames()))
@@ -128,7 +132,9 @@ test_that("as.POSIXlt()", {
     expect_equal(format(as.POSIXlt(dtl), digits = 6L), "12016-02-19 10:10:10.123456")
 })
 
-test_that("clock classes", {
+test_that("{clock} classes", {
+    skip_if_not_installed("clock", "0.7.3")
+
     dt <- as_datetimeoffset("2020-03-23T04:04:04Z")
     dtn <- datetimeoffset(-7971, 5, 31, 10, tz = "GMT")
     dtl <- datetimeoffset(12016, 2, 19, 10, tz = "GMT")

--- a/tests/testthat/test-invalid.r
+++ b/tests/testthat/test-invalid.r
@@ -1,4 +1,6 @@
 test_that("detect_invalid()", {
+    skip_if_not_installed("clock", "0.7.3")
+
     dts <- c("2019-04-30T03:30:00", "2019-04-31T02:30:00")
     dts <- as_datetimeoffset(dts)
     expect_equal(clock::invalid_detect(dts), c(FALSE, TRUE))


### PR DESCRIPTION
Bumps required {clock} version to prevent R CMD check ERROR on CRAN

closes #64